### PR TITLE
[Enhancement] Removes dependency on dotenv while providing a classic …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ And then execute:
 Or install it yourself as:
 
     $ gem install semantics
-    
-    
-Create a .env file containing your API TOKEN
 
-``` TOKEN <YOUR API TOKEN>```
+
+Set the API token using this simple code:
+
+```ruby
+  Semantics.configure do |config|
+    config.api_token = 'YOUR_API_TOKEN'
+  end
+```
 
 ## Getting Started
 
@@ -40,28 +44,28 @@ Create an Object:
 
 Display all Objects from different Content Projects:
 
-```  Semantics::Thing.all ``` 
+```  Semantics::Thing.all ```
 
 Display Objects from a specific Content Project:
 
-```  Semantics::Thing.all(content_project_id) ``` 
+```  Semantics::Thing.all(content_project_id) ```
 
 Find an Object:
 
-```  Semantics::Thing.find(content_project_id, object_id) ``` 
+```  Semantics::Thing.find(content_project_id, object_id) ```
 
 Update an Object:
 
-``` thing.update(uid, name, pure_date) ``` 
+``` thing.update(uid, name, pure_date) ```
 
-Destroy an Object 
+Destroy an Object
 
 ``` thing.destroy ```
 
 ## Example workflow
 
 
-``` 
+```
 # creating a new Content Project with engine configuration 526
 
 content_project = Semantics::ContentProject.create('New Project', 526)
@@ -71,7 +75,7 @@ thing = Semantics::Thing.create(content_project.id, "MyId", "FancyThing", { 'key
 
 # trigger content generation
 thing.generate
-``` 
+```
 
 ## Development
 
@@ -87,4 +91,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/semantics.rb
+++ b/lib/semantics.rb
@@ -1,10 +1,23 @@
-require 'dotenv'
 require 'httparty'
 
 require_relative 'semantics/api_error'
 require_relative 'semantics/api_misssing_token_error'
 require_relative 'semantics/ax_data'
-require_relative 'semantics/configuration'
 require_relative 'semantics/content_project'
 require_relative 'semantics/login'
 require_relative 'semantics/thing'
+
+module Semantics
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_accessor :api_token
+  end
+end

--- a/lib/semantics/ax_data.rb
+++ b/lib/semantics/ax_data.rb
@@ -13,7 +13,7 @@ module Semantics
     def self.headers
       {
         'Content-Type' => 'application/json',
-        'Authorization' => TOKEN
+        'Authorization' => Semantics.configuration.api_token
       }
     end
 

--- a/lib/semantics/configuration.rb
+++ b/lib/semantics/configuration.rb
@@ -1,5 +1,0 @@
-module Semantics
-  Dotenv.load
-  TOKEN = ENV['TOKEN'] || raise(
-    ApiMissingTokenError, 'No .env file with token present')
-end

--- a/semantics.gemspec
+++ b/semantics.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'vcr', '~> 2.9'
+  spec.add_development_dependency 'webmock', '~> 2.3'
+  spec.add_development_dependency 'sinatra', '~> 1.4'
+  spec.add_development_dependency 'pry'
   spec.add_dependency 'json'
   spec.add_dependency 'httparty'
-  spec.add_dependency 'dotenv'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,14 +3,16 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'semantics'
 require 'rspec/its'
 require 'webmock/rspec'
+require 'pry'
 require './spec/support/fake_ax_semantics'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
-Semantics::TOKEN = 'Token 1234'.freeze
+Semantics.configure do |config|
+  config.api_token = 'Token 1234'.freeze
+end
 
 RSpec.configure do |config|
-
   def headers
     {
       Authorization: 'Token 1234',


### PR DESCRIPTION
This removes the dependency on dotenv and removes the TOKEN constant and uses instead a classical `config` block to setup the API Token.